### PR TITLE
Modernize the Windows setup.

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,3 +1,16 @@
-:: Just delegate to the Unixy script.
-bash %RECIPE_DIR%\build.sh
+:: Trailing semicolon in this variable as set by current (2017/01)
+:: conda-build breaks us. Manual fix:
+set "MSYS2_ARG_CONV_EXCL=/AI;/AL;/OUT;/out"
+:: Delegate to the Unixy script. We need to translate the key path variables
+:: to be Unix-y rather than Windows-y, though.
+set "saved_recipe_dir=%RECIPE_DIR%"
+FOR /F "delims=" %%i IN ('cygpath.exe -u -p "%PATH%"') DO set "PATH_OVERRIDE=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%PREFIX%"') DO set "PREFIX=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%PYTHON%"') DO set "PYTHON=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%RECIPE_DIR%"') DO set "RECIPE_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%SP_DIR%"') DO set "SP_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%SRC_DIR%"') DO set "SRC_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%STDLIB_DIR%"') DO set "STDLIB_DIR=%%i"
+bash -x %saved_recipe_dir%\build.sh
 if errorlevel 1 exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -6,8 +6,11 @@ IFS=$' \t\n' # workaround for conda 4.2.13+toolchain bug
 # Adopt a Unix-friendly path if we're on Windows (see bld.bat).
 [ -n "$PATH_OVERRIDE" ] && export PATH="$PATH_OVERRIDE"
 
-# On Windows we want $LIBRARY_PREFIX not $PREFIX.
-if [ -n "$LIBRARY_PREFIX" ] ; then
+# On Windows we want $LIBRARY_PREFIX not $PREFIX, but its Unix path
+# currently works out to "/" which needs special-casing.
+if [ "$LIBRARY_PREFIX" = / ] ; then
+    useprefix=""
+elif [ -n "$LIBRARY_PREFIX" ] ; then
     useprefix="$LIBRARY_PREFIX"
 else
     useprefix="$PREFIX"
@@ -21,7 +24,7 @@ if [ -n "$VS_MAJOR" ] ; then
     autoreconf_args=(
         --force
         --install
-        -I "$PREFIX/Library/mingw-w$ARCH/share/aclocal"
+        -I "$useprefix/mingw-w$ARCH/share/aclocal"
     )
     autoreconf "${autoreconf_args[@]}"
 fi

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -3,27 +3,51 @@
 set -e
 IFS=$' \t\n' # workaround for conda 4.2.13+toolchain bug
 
-# Some X.org packages have config.{guess,sub} too old to properly build on
-# 64-bit Windows! Because this package stores generic X.org build helpers, we
-# use it to distribute more recent versions of those file. Other X.org
-# packages should have this one as a build-time dependency and copy the files
-# into their unpacked source directories.
+# Adopt a Unix-friendly path if we're on Windows (see bld.bat).
+[ -n "$PATH_OVERRIDE" ] && export PATH="$PATH_OVERRIDE"
 
-mkdir -p $PREFIX/share/util-macros
+# On Windows we want $LIBRARY_PREFIX not $PREFIX.
+if [ -n "$LIBRARY_PREFIX" ] ; then
+    useprefix="$LIBRARY_PREFIX"
+else
+    useprefix="$PREFIX"
+fi
+
+# On Windows we need to regenerate the configure scripts.
+if [ -n "$VS_MAJOR" ] ; then
+    am_version=1.15 # keep sync'ed with meta.yaml
+    export ACLOCAL=aclocal-$am_version
+    export AUTOMAKE=automake-$am_version
+    autoreconf_args=(
+        --force
+        --install
+        -I "$PREFIX/Library/mingw-w$ARCH/share/aclocal"
+    )
+    autoreconf "${autoreconf_args[@]}"
+fi
+
+# We used to provide our own config.{guess,sub} on Windows; now we are
+# transitioning to running autoreconf in all Windows builds, since the
+# distributed configure scripts have a lot of Windows special-casing that
+# fails on msys2 unless we use msys2's autotools. But to smooth the transition
+# we'll keep distributing the files for a bit.
+
+mkdir -p $useprefix/share/util-macros
 
 for f in config.guess config.sub ; do
     cp -p $RECIPE_DIR/$f .
-    cp -p $RECIPE_DIR/$f $PREFIX/share/util-macros/
+    cp -p $RECIPE_DIR/$f $useprefix/share/util-macros/
 done
 
-export PKG_CONFIG_LIBDIR=$PREFIX/lib/pkgconfig:$PREFIX/share/pkgconfig
+export PKG_CONFIG_LIBDIR=$useprefix/lib/pkgconfig:$useprefix/share/pkgconfig
 
 configure_args=(
-    --prefix=$PREFIX
+    --prefix=$useprefix
     --disable-dependency-tracking
     --disable-selective-werror
     --disable-silent-rules
 )
+
 ./configure "${configure_args[@]}"
 make -j${CPU_COUNT}
 make install

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -24,7 +24,7 @@ if [ -n "$VS_MAJOR" ] ; then
     autoreconf_args=(
         --force
         --install
-        -I "$useprefix/mingw-w$ARCH/share/aclocal"
+        -I "$useprefix/mingw-w64/share/aclocal" # note: this is correct for win32 also!
     )
     autoreconf "${autoreconf_args[@]}"
 fi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,6 +3,7 @@
 {% set name = "xorg-" ~ xorg_name %}
 {% set version = "1.19.0" %}
 {% set sha256 = "2835b11829ee634e19fa56517b4cfc52ef39acea0cd82e15f68096e27cbed0ba" %}
+{% set am_version = "1.15" %}
 
 package:
   name: {{ name|lower }}
@@ -14,21 +15,24 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   detect_binary_files_with_prefix: true
 
 requirements:
   build:
-    - curl  # [win]
+    - m2-autoconf  # [win]
+    - m2-automake{{ am_version }}  # [win]
+    - m2-libtool  # [win]
     - m2w64-pkg-config  # [win]
+    - m2w64-toolchain  # [win]
     - pkg-config  # [not win]
     - posix  # [win]
     - toolchain
 
 test:
   commands:
-    - conda inspect linkages -p $PREFIX {{ name }}  # [not win]
-    - conda inspect objects -p $PREFIX {{ name }}  # [osx]
+    - conda inspect linkages -p $PREFIX $PKG_NAME  # [not win]
+    - conda inspect objects -p $PREFIX $PKG_NAME  # [osx]
 
 about:
   home: https://www.x.org/


### PR DESCRIPTION
This updates the Windows stuff based on the experience I've gained building
the downstream X.org libraries this far. The key new bit is that it looks like
we're really supposed to use $LIBRARY_PREFIX as our install prefix rather than
$PREFIX. I also run autoreconf which looks like it will be necessary for the
Windows builds. Not actually needed for this package since it just installs
macro files, but I want the build scripts to be as consistent as possible.